### PR TITLE
Update _nav_default_width at each recalcNav call.

### DIFF
--- a/app/js/jquery.okayNav.js
+++ b/app/js/jquery.okayNav.js
@@ -332,7 +332,7 @@
                 visible_nav_items = self.getVisibleItemCount(),
                 collapse_width = $nav_visible.outerWidth(true) + _toggle_icon_width,
                 expand_width = space_taken + _last_visible_child_width + _toggle_icon_width,
-                expandAll_width = space_taken - nav_full_width + _nav_default_width;
+                expandAll_width = space_taken - nav_full_width + self.getChildrenWidth($navigation);
 
             if (wrapper_width > expandAll_width) {
                 self._expandAllItems();


### PR DESCRIPTION
Update _nav_default_width at each recalcNav call. Usefull if menu items were added/removed in the meantime. 
I my use case i can add and remove nav nodes from the nav. I want to avoid destroy and reattach okayNav to take new nodes into account. So i updated recalcNav method to update at each call _nav_default_width.
