### PR TITLE
Declare variable self in order to avoid global assignment

### DIFF
--- a/app/js/jquery.okayNav.js
+++ b/app/js/jquery.okayNav.js
@@ -26,7 +26,8 @@
 }(function($) {
     // Defaults
 
-    var okayNav = 'okayNav',
+    var self,
+        okayNav = 'okayNav',
         defaults = {
             parent: '', // will call nav's parent() by default
             toggle_icon_class: 'okayNav__menu-toggle',


### PR DESCRIPTION
In line 48 (now 49) self is assigned globally to windows which could break a lot of things in applications and other libraries.
